### PR TITLE
Fix minor text issues: typos, grammar, consistency, etc.

### DIFF
--- a/src/OptionScreen.js
+++ b/src/OptionScreen.js
@@ -172,7 +172,7 @@ export default function OptionScreen({state, popup, updateState, setTotalClicks}
         {spaces()}<button onClick={cheat}>Cheat</button>
       </p>}
       <details>
-        <summary>Pop-Up-Settings</summary>
+        <summary>Pop-Up Settings</summary>
         <p>
           {spaces()}<MultiOptionButton settingName="offlineProgressPopup" statusList={["ON","LAUNCH","OFF"]} state={state} updateState={updateState} setTotalClicks={setTotalClicks}
             description="Offline Progress Pop-Up" tooltip="Controls whether the offline progress popup is shown" tooltipList={["Shown at launch and after inactive periods","Only shown at launch/loading", "Never shown"]}/>
@@ -183,7 +183,7 @@ export default function OptionScreen({state, popup, updateState, setTotalClicks}
         </p> */}
         <p>
         {spaces()}<MultiOptionButton settingName="valueReduction" statusList={["ON","OFF"]} state={state} updateState={updateState} setTotalClicks={setTotalClicks}
-          description="Decreasing Formula Pop-Up" tooltip="Controls whether the confirmation popup for decreasing an X-Value is shown" tooltipList={["Show popup","Do not show popup"]}/>
+          description="Decreasing Formula Pop-Up" tooltip="Controls whether the confirmation popup for decreasing an x value is shown" tooltipList={["Show popup","Do not show popup"]}/>
         </p>
         <p>
           {spaces()}<MultiOptionButton settingName="xResetPopup" statusList={["ON","OFF","SMART","SAFE"]} state={state} updateState={updateState} setTotalClicks={setTotalClicks}
@@ -199,7 +199,7 @@ export default function OptionScreen({state, popup, updateState, setTotalClicks}
         </p>}
         {(state.destinyStars > 1 || state.progressionLayer > 0) && <p>
           {spaces()}<MultiOptionButton settingName="alphaAbortPopup" statusList={["DOUBLE", "ON","OFF"]} state={state} updateState={updateState} setTotalClicks={setTotalClicks}
-            description="Abort Alpha Pop-Up" tooltip="Controls whether the confirmation popup for aborting an Alpha run is shown" tooltipList={["Show two popups", "Show one popup","Do not show popup"]}/>
+            description="Abort Alpha Pop-Up" tooltip="Controls whether the confirmation popup for aborting an Alpha Run is shown" tooltipList={["Show two popups", "Show one popup","Do not show popup"]}/>
         </p>}
         {(state.destinyStars > 1 || state.progressionLayer > 0) && <p>
           {spaces()}<MultiOptionButton settingName="alphaUpgradePopup" statusList={["ON","OFF"]} state={state} updateState={updateState} setTotalClicks={setTotalClicks}
@@ -216,7 +216,7 @@ export default function OptionScreen({state, popup, updateState, setTotalClicks}
       </details>
       <br/>
       <details>
-        <summary>Hotkey-Settings</summary>
+        <summary>Hotkey Settings</summary>
         <p>
           {spaces()}<MultiOptionButton settingName="hotkeyApplyFormula" statusList={["ON","OFF"]} state={state} updateState={updateState} setTotalClicks={setTotalClicks}
             description="Apply Formula Hotkeys [1/2/3]" tooltip="Controls whether number keys can be used to apply formulas" tooltipList={["Hotkeys Enabled", "Hotkeys Disabled"]}/>

--- a/src/alpha/AlphaChallengeTab.js
+++ b/src/alpha/AlphaChallengeTab.js
@@ -18,7 +18,7 @@ export const alphaChallengeDictionary = {
     "DECREASE": {
         id:"DECREASE",
         title:"Decay",
-        description:"All X-Values decay at a rate of 10% per second, rounded up.",
+        description:"All x values decay at a rate of 10% per second, rounded up.",
     },
     "LIMITED": {
         id:"LIMITED",
@@ -28,7 +28,7 @@ export const alphaChallengeDictionary = {
     "RESETOTHER": {
         id:"RESETOTHER",
         title:"Selfish",
-        description:"Applying a formula resets all other X-Values.",
+        description:"Applying a formula resets all other x values.",
     },
     "NEWONLY": {
         id:"NEWONLY",
@@ -92,10 +92,21 @@ export default function AlphaChallengeTab({state, updateState, popup}) {
 
     const challengeBonus = getChallengeBonus(state)
 
+    //allow "Your {challengeBonus.full} challenge completions and {challengeBonus.segment} segment completions" to be
+    //grammatically correct no matter the count of completions
+    let challengeCompletions = "completions"
+    let segmentCompletions = "completions"
+    if(challengeBonus.full === 1)  {
+        challengeCompletions = "completion"
+    }
+    if(challengeBonus.segment === 1) {
+        segmentCompletions = "completion"
+    }
+
     return (<div style={{marginLeft:"20px"}}>
         <h2>Challenges</h2>
-        Challenges are like normal Alpha-Runs, but with additional constraints.<br/> You are rewarded for each successful x-Reset and for completing the entire run!<br/>
-        {challengeBonus.full === 13 ? <>You completed all challenges, boosting your Formula Efficiency by {challengeBonus.bonus.toFixed(2)}.</>: <>Your {challengeBonus.full} challenge completions and {challengeBonus.segment} segment completions boost your Formula Efficiency by {challengeBonus.bonus.toFixed(2)}.</>}
+        Challenges are like normal Alpha Runs, but with additional constraints.<br/> You are rewarded for each successful x-Reset and for completing the entire run!<br/>
+        {challengeBonus.full === 13 ? <>You completed all challenges, boosting your Formula Efficiency by {challengeBonus.bonus.toFixed(2)}.</>: <>Your {challengeBonus.full} challenge {challengeCompletions} and {challengeBonus.segment} segment {segmentCompletions} boost your Formula Efficiency by {challengeBonus.bonus.toFixed(2)}.</>}
         {state.currentChallenge && <p>You are currently in the "{state.currentChallengeName}" Challenge.</p>}
         <p>
             <button style={{color:"black"}} disabled={!state.insideChallenge} onClick={exitAlphaChallenge}>Exit Challenge</button>

--- a/src/alpha/AlphaResearchTab.js
+++ b/src/alpha/AlphaResearchTab.js
@@ -113,7 +113,7 @@ export default function AlphaResearchTab({state, updateState, setTotalClicks}) {
             <div>Total Level: {formatNumber(totalLevel, state.numberFormat, 2)}</div><br/><br/>
         </>}
 
-        Research speed is boosted by your highscores but higher levels take longer.
+        Research speed is boosted by your high scores but higher levels take longer.
         {getMaxxedResearchBonus(state).count > 0 && <><br/>Every maxxed Research Bar doubles your Formula Efficiency (x{getMaxxedResearchBonus(state).bonus}).</>}
         <br/><br/><AlphaResearchBar key="x" research={researchDictonary["x"]} state={state} updateState={updateState}/>
         <br/><br/><AlphaResearchBar key="x'" research={researchDictonary["x'"]} state={state} updateState={updateState}/>

--- a/src/alpha/AlphaStonesTab.js
+++ b/src/alpha/AlphaStonesTab.js
@@ -65,8 +65,8 @@ export default function AlphaStonesTab({state, popup, updateState}) {
                 )}</div>)}
                 <br/>
                 {xBonus > 0 && <div style={{fontSize:"20px",fontWeight:"bold"}}>{spaces()}s<sub>x</sub> = {getStoneCalculationForX(state, stoneTable)} = {formatNumber(xBonus, state.settings.numberFormat)}<br/></div>}
-                {xBonus > 1 && <div>{spaces()} s<sub>x</sub> multiplies your Starting x<br/></div>}
-                {xBonus > 1 && <div>{spaces()} Your total Starting x is {formatNumber(getStartingX(state),state.settings.numberFormat, 2)}</div>}
+                {xBonus > 1 && <div>{spaces()} s<sub>x</sub> multiplies your starting x<br/></div>}
+                {xBonus > 1 && <div>{spaces()} Your total starting x is {formatNumber(getStartingX(state),state.settings.numberFormat, 2)}</div>}
             </>}
         </div>)
 }

--- a/src/alpha/AlphaUpgradeTab.js
+++ b/src/alpha/AlphaUpgradeTab.js
@@ -124,8 +124,8 @@ return (
         <br/><br/>
         <h2>Info</h2>
         <p>You have {formatNumber(state.alpha, state.settings.numberFormat,2)} Alpha Token{state.alpha !== 1 && "s"}!</p>
-        <p>Time in current Alpha run: {secondsToHms(state.currentAlphaTime / 1000)}{state.isFullyIdle && <> (Fully Idle)</>}</p>
-        {state.bestAlphaTime<1e50 && <p>Fastest Alpha run: {secondsToHms(state.bestAlphaTime / 1000, true)}</p>}
+        <p>Time in current Alpha Run: {secondsToHms(state.currentAlphaTime / 1000)}{state.isFullyIdle && <> (Fully Idle)</>}</p>
+        {state.bestAlphaTime<1e50 && <p>Fastest Alpha Run: {secondsToHms(state.bestAlphaTime / 1000, true)}</p>}
         {state.clearedChallenges.FULLYIDLE && <>
             <p>Best Fully Idle: {formatNumber(state.bestIdleTimeAlpha, state.settings.numberFormat, 2)}&alpha; in {secondsToHms(state.bestIdleTime  / 1000, true)}</p>
         </>}

--- a/src/endings/EndingDictionary.js
+++ b/src/endings/EndingDictionary.js
@@ -65,21 +65,21 @@ const evilActions = [
     {
         title: "ENHANCE WORLD FORMULA",
         durationSeconds: 10,
-        headerText: <>The World formula has absorbed enough evil energy to be enhanced!</>,
+        headerText: <>The World Formula has absorbed enough evil energy to be enhanced!</>,
     },
     {
         title: "ELIMINATE HALF OF POPULATION",
         durationSeconds: 5,
         split: 2,
         requirement: 7999999988,
-        headerText: <>The World formula is at maximum power!</>,
+        headerText: <>The World Formula is at maximum power!</>,
     },
     {
         title: "KILL A PERSON",
         progress: 1,
         durationSeconds: 10,
         requirement: 7999999999,
-        headerText: <>Your Hirees are dead! Even the World Formula is disgusted by your Actions and refuses to help.<br/><br/>You will have to finish this completely on your own.</>
+        headerText: <>Your hirees are dead! Even the World Formula is disgusted by your actions and refuses to help.<br/><br/>You will have to finish this completely on your own.</>
     },
     {
         title: "KILL A PERSON",
@@ -119,7 +119,7 @@ const goodActions = [
         headerText: <>The World Formula lets you achieve anything!</>,
     },
     {
-        title: "HELP AN ELDERLY",
+        title: "HELP AN ELDERLY PERSON",
         durationSeconds: 3,
     },
     {
@@ -180,14 +180,14 @@ const goodActions = [
     {
         title: "ENHANCE WORLD FORMULA",
         durationSeconds: 10,
-        headerText: <>The World formula has absorbed enough good energy to be enhanced!</>,
+        headerText: <>The World Formula has absorbed enough good energy to be enhanced!</>,
     },
     {
         title: "CURE HALF",
         durationSeconds: 5,
         requirement: 29988,
         split: 2,
-        headerText: <>The World formula is at maximum power!</>,
+        headerText: <>The World Formula is at maximum power!</>,
     },
     {
         title: "CURE AN ILLNESS",
@@ -283,14 +283,14 @@ const trueActions = [
     {
         title: "ENHANCE WORLD FORMULA",
         durationSeconds: 10,
-        headerText: <>The World formula has absorbed enough incremental energy to be enhanced!</>,
+        headerText: <>The World Formula has absorbed enough incremental energy to be enhanced!</>,
     },
     {
         title: "ADD ANOTHER E",
         durationSeconds: 1,
         repeat: 29,
         getValue: (r)=>("1" + ("e").repeat(r+3) + "5"),
-        headerText: <>The World formula is at maximum power!</>,
+        headerText: <>The World Formula is at maximum power!</>,
     },
     {
         title: "ROUND UP GENEROUSLY",
@@ -316,43 +316,43 @@ const trueActions = [
     {
         title: "TAKE A DEEP BREATH",
         durationSeconds: 10,
-        headerText: <>The World formula is at maximum power!<br/><br/>You found inner peace!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You found inner peace!</>,
     },
     {
         title: "FIND INNER PEACE",
         durationSeconds: 5,
-        headerText: <>The World formula is at maximum power!<br/><br/>You found inner peace!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You found inner peace!</>,
     },
     {
         title: "FIND INNER PEACE",
         durationSeconds: 5,
-        headerText: <>The World formula is at maximum power!<br/><br/>You found 2 inner peaces!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You found 2 inner peaces!</>,
     },
     {
         title: "FIND INNER PEACE",
         durationSeconds: 5,
-        headerText: <>The World formula is at maximum power!<br/><br/>You found 3 inner peaces!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You found 3 inner peaces!</>,
     },
     {
         title: "FIND INNER PEACE",
         durationSeconds: 5,
-        headerText: <>The World formula is at maximum power!<br/><br/>You found 4 inner peaces!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You found 4 inner peaces!</>,
     },
     {
         title: "FIND INNER PEACE",
         durationSeconds: 5,
-        headerText: <>The World formula is at maximum power!<br/><br/>You found 5 inner peaces!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You found 5 inner peaces!</>,
     },
     {
-        title: "PEACE THE PEACES TOGETHER",
+        title: "PIECE THE PEACES TOGETHER",
         durationSeconds: 5,
-        headerText: <>The World formula is at maximum power!<br/><br/>You found 6 inner peaces!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You found 6 inner peaces!</>,
     },
     {
         title: "PREPARE TO MOVE ON",
         getValue: ()=>0,
         durationSeconds: 30,
-        headerText: <>The World formula is at maximum power!<br/><br/>You solved the peace puzzle!</>,
+        headerText: <>The World Formula is at maximum power!<br/><br/>You solved the peace puzzle!</>,
     },
     {
         title: "MOVE ON",
@@ -474,7 +474,7 @@ export const endingList = {
         headerText: <>~Skipped Ending~</>,
         quoteText: <>&ldquo;With great power comes great responsibility.&rdquo;</>,
         teaseHeaderText: <>~??????? ??????~</>,
-        storyText: <>Who cares about the story anyway.<br/>You just finished World Formula Any%!</>,
+        storyText: <>Who cares about the story anyway?<br/>You just finished World Formula Any%!</>,
         final:true,
         endingName:"skipped",
         instaDestiny:true,

--- a/src/formulas/FormulaScreen.js
+++ b/src/formulas/FormulaScreen.js
@@ -58,7 +58,7 @@ export const shopFormulas=[
 export default function FormulaScreen({state, updateState, setTotalClicks, popup}) {
     const resetXValues = ()=>{
       const isProgressAvailable = state.xValue[0] >= nextUnlockCost || state.xValue[0] >= differentialTarget || state.xValue[0] >= alphaTarget
-      popup.confirm("Your X values are reset, but you can change your equipped formulas.",()=>{
+      popup.confirm("Your x values are reset, but you can change your equipped formulas.",()=>{
         popup.confirm("Your x is high enough to unlock something or progress instead. Do you still want to do a Basic Research?",()=>{
           updateState({name: "resetXValues"})
           setTotalClicks((x)=>x+1)
@@ -92,7 +92,7 @@ export default function FormulaScreen({state, updateState, setTotalClicks, popup
     }
 
     const negativeSpaceInfo = ()=>{
-      popup.alert(<>When an X-Value becomes negative, you enter Negative Space.<br/>While in Negative Space: x-Resets, Alpha-Resets and Challenge Completions are disabled.<br/>You can leave Negative Space by doing a Basic Reset or aborting your run.</>)
+      popup.alert(<>When an x value becomes negative, you enter Negative Space.<br/>While in Negative Space: x-Resets, Alpha-Resets and Challenge Completions are disabled.<br/>You can leave Negative Space by doing a Basic Reset or aborting your run.</>)
     }
 
     const completeChallenge = ()=>{
@@ -179,7 +179,7 @@ export default function FormulaScreen({state, updateState, setTotalClicks, popup
 
     return (<div style={{color: "#99FF99", marginLeft: "10px"}}>
         <div className="row" style={{marginTop:"0px"}}><div className="column">
-        <h2 style={{marginTop:"0px"}}>X Values</h2>
+        <h2 style={{marginTop:"0px"}}>x values</h2>
             <ValueTable values={state.xValue} diffs={state.avgXPerSecond} baseName={"x"} maxTier={state.highestXTier} numberFormat={state.settings.numberFormat}/>
             <br/>
             {!state.insideChallenge && state.xValue[0] >= Infinity ?
@@ -205,7 +205,7 @@ export default function FormulaScreen({state, updateState, setTotalClicks, popup
           <h2>My Formulas</h2>
           <FormulaTable state={state} updateState={updateState} popup={popup} setTotalClicks={setTotalClicks} formulaNames={inventoryFormulas} context="my"/>
           {state.progressionLayer === 0 && state.formulaUnlockCount >= 2 && state.highestXTier === 0 && 
-            <p>Hint: Apply formulas repeatedly by holding the button or using the 1/2/3-Keys.</p>
+            <p>Hint: Apply formulas repeatedly by holding the button or using the 1/2/3 keys.</p>
           }
           <p>
             {(state.alphaUpgrades.MEEQ) && <>
@@ -241,8 +241,8 @@ export default function FormulaScreen({state, updateState, setTotalClicks, popup
             {state.activeChallenges.LIMITED && <p>You can apply {100 - state.formulaApplyCount} more formulas.</p>}
             {(state.xResetCount > 0 || state.highestXTier > 0 || state.progressionLayer > 0) && state.highestXTier < 3 && state.xValue[0] < differentialTarget && <p>Reach x={formatNumber(differentialTarget, state.settings.numberFormat)} for the next x-Reset</p>}
             {(state.xResetCount > 0 || state.highestXTier > 0) && state.progressionLayer === 0 && state.highestXTier < 3 && state.xValue[0] >= differentialTarget && <p style={{color:"#00FF00", fontWeight:"bold"}}>{sResetName}-Reset is now available! (See button above!)</p>}
-            {state.progressionLayer > 0 && !state.insideChallenge && !state.inNegativeSpace && state.xValue[0] > differentialTarget && <p>{sResetName}-Reset Highscore: x={formatNumber(state.xHighScores[state.highestXTier], state.settings.numberFormat,3)}</p>}
-            {state.activeChallenges.FORMULAGOD && <p>Formula God Highscore: x={formatNumber(state.formulaGodScores[0], state.settings.numberFormat,3)}</p>}
+            {state.progressionLayer > 0 && !state.insideChallenge && !state.inNegativeSpace && state.xValue[0] > differentialTarget && <p>{sResetName}-Reset High Score: x={formatNumber(state.xHighScores[state.highestXTier], state.settings.numberFormat,3)}</p>}
+            {state.activeChallenges.FORMULAGOD && <p>Formula God High Score: x={formatNumber(state.formulaGodScores[0], state.settings.numberFormat,3)}</p>}
             {state.progressionLayer >= 1 && state.highestXTier === 3 && state.xValue[0] < alphaTarget && !state.insideChallenge && <p>Reach x={formatNumber(alphaTarget, state.settings.numberFormat)} to perform an &alpha;-Reset</p>}
             {state.highestXTier === 3 && state.xValue[0] < alphaTarget && state.insideChallenge && <p>Reach x={formatNumber(alphaTarget,state.settings.numberFormat)} to complete the challenge</p>}
             {state.progressionLayer >= 1 && state.highestXTier === 3 && !state.inNegativeSpace && !state.insideChallenge && state.xValue[0] >= alphaTarget && <p>Alpha Reset for {alphaRewardTier.alpha * Math.pow(2,state.baseAlphaLevel)} &alpha;.{alphaRewardTier.next && <>&nbsp;(Next: {alphaRewardTier.nextAlpha * Math.pow(2,state.baseAlphaLevel)} &alpha; at x={formatNumber(alphaRewardTier.next)})</>}</p>}

--- a/src/mails/MailDictionary.js
+++ b/src/mails/MailDictionary.js
@@ -21,7 +21,7 @@ export const mailDictionary = {
     "What":{
         id: "What",
         title: "Re: What are you talking about?",
-        content: <>I noticed how obsessed you were lately with researching formulas and large numbers, so I was sure you must have heard about it. About the mythical formula that is said to transcend maths itself. I've spent years following traces, not even sure why it is important or what my ultimate goal is. My curiousity led me deeper and deeper into the rabbit hole, but it was all in vain. Save yourself the trouble and stop digging deeper.</>,
+        content: <>I noticed how obsessed you were lately with researching formulas and large numbers, so I was sure you must have heard about it. About the mythical formula that is said to transcend maths itself. I've spent years following traces, not even sure why it is important or what my ultimate goal is. My curiosity led me deeper and deeper into the rabbit hole, but it was all in vain. Save yourself the trouble and stop digging deeper.</>,
         responses: [<>What did you find out so far?</>, <>Yeah, I'd rather not get involved in this.</>],
         sender: "Mister Y",
         check: (state)=>(state.xValue[0] > 520e6 && state.highestXTier >= 1),
@@ -68,7 +68,7 @@ export const mailDictionary = {
     "Joined":{
         id: "Joined",
         title: "About the Academy",
-        content: <>So you've joined the Academy to aid your goals? They can be very helpful and you will need all help you can get. But be careful, you must not let them know you are looking for the world formula. We don't want the Academy to steal the fruits of our endeavors.</>,
+        content: <>So you've joined the Academy to aid your goals? They can be very helpful and you will need all help you can get. But be careful, you must not let them know you are looking for the World Formula. We don't want the Academy to steal the fruits of our endeavors.</>,
         sender: "Mister Y",
         check: (state)=>(state.progressionLayer >= 1 && state.xValue[0] > 300e6 && state.highestXTier >=3),
         delay: 30,
@@ -77,7 +77,7 @@ export const mailDictionary = {
     "How":{
         id: "How",
         title: "But how???",
-        content: <>Hearing about the world formula, you may be wondering how to achieve such a state of mind, how to <i>discover</i> the World Formula for yourself. One must break out of the prison imposed by ones formulas. Find unlimited growth. Yearn for <b>Infinity</b>. Yet one must not just invent new formulas, instead one must <b>exploit the core of mathematics</b> to break free of the bounds which constrain ones conciousness. And those who get blinded by greed and stop being careful may end up stuck with infinitely many problems, or deep down in the depths of hell.</>,
+        content: <>Hearing about the World Formula, you may be wondering how to achieve such a state of mind, how to <i>discover</i> the World Formula for yourself. One must break out of the prison imposed by one's formulas. Find unlimited growth. Yearn for <b>Infinity</b>. Yet one must not just invent new formulas, instead one must <b>exploit the core of mathematics</b> to break free of the bounds which constrain one's consciousness. And those who get blinded by greed and stop being careful may end up stuck with infinitely many problems, or deep down in the depths of hell.</>,
         sender: "Mister Y",
         check: (state)=>(state.alpha >= 42),
         delay: 500,
@@ -341,7 +341,7 @@ export const mailDictionary = {
     "Research":{
         id: "Research",
         title: "Research",
-        content: <>As a part of our Academy, you may now use our institutions for Research. You find Research on the Alpha tab. For Research it is important to not do your x-Resets immediately, but instead aim for a better highscore. The speed of your research is directly proportional to your highscores. If a highscore gets very much ahead of a Research level, you can even claim multiple levels at once! Research may not seem to help much when you first start, but its benefits grow exponentially, and they will soon speed up your daily work greatly.</>,
+        content: <>As a part of our Academy, you may now use our institutions for Research. You find Research on the Alpha tab. For Research it is important to not do your x-Resets immediately, but instead aim for a better high score. The speed of your research is directly proportional to your high scores. If a high score gets very much ahead of a Research level, you can even claim multiple levels at once! Research may not seem to help much when you first start, but its benefits grow exponentially, and they will soon speed up your daily work greatly.</>,
         responses: [<>UNLOCK RESEARCH</>],
         sender: "Academy",
         check: (state)=>(state.alphaUpgrades.SLOT || state.alphaUpgrades.AAPP || state.alphaUpgrades.AUNL),
@@ -351,7 +351,7 @@ export const mailDictionary = {
     "Challenges":{
         id: "Challenges",
         title: "Academy Projects",
-        content: <>We are very happy with the results of your Research so far. As such we would like to invite you to participate in more complex projects. Sometimes true wisdom can only be achieved by restricting ones options, forcing one to assume new perspectives. On the Alpha tab you can find our projects under Challenges. Every Challenge and Challenge segment you clear will allow us to make your formulas more efficient. And once you have proven yourself, there will be special rewards if you can help with the toughest Challenges our Academy faces right now.</>,
+        content: <>We are very happy with the results of your Research so far. As such we would like to invite you to participate in more complex projects. Sometimes true wisdom can only be achieved by restricting one's options, forcing one to assume new perspectives. On the Alpha tab you can find our projects under Challenges. Every Challenge and Challenge segment you clear will allow us to make your formulas more efficient. And once you have proven yourself, there will be special rewards if you can help with the toughest Challenges our Academy faces right now.</>,
         responses: [<>UNLOCK CHALLENGES</>],
         sender: "Academy",
         check: (state)=>(state.researchLevel["x"] >= 100 && state.researchLevel["x'"] >= 100 && state.researchLevel["x''"] >= 100 && state.researchLevel["x'''"] >= 100),
@@ -391,7 +391,7 @@ export const mailDictionary = {
     "Idle":{
         id: "Idle",
         title: "Master of Idle",
-        content: <>Congratulations on finishing the Master of Idle Challenge. We improved your Passive Alpha gain, from now on you will get Alpha based on your best fully idle Alpha run. You can check it on the Alpha upgrades tab.</>,
+        content: <>Congratulations on finishing the Master of Idle Challenge. We improved your Passive Alpha gain, from now on you will get Alpha based on your best fully idle Alpha Run. You can check it on the Alpha upgrades tab.</>,
         sender: "Academy",
         check: (state)=>(state.clearedChallenges["FULLYIDLE"]),
         delay: 90,
@@ -399,7 +399,7 @@ export const mailDictionary = {
     "God":{
         id: "God",
         title: "Formula God",
-        content: <>Thank you for attempting the Formula God Challenge. That one is truly giving us nightmares. However, we are able to support you by multiplying your research speeds by your respective best scores in the Formula God Challenge. You can check this special boost on the Research tab. Keep trying and improving those highscores!</>,
+        content: <>Thank you for attempting the Formula God Challenge. That one is truly giving us nightmares. However, we are able to support you by multiplying your research speeds by your respective best scores in the Formula God Challenge. You can check this special boost on the Research tab. Keep trying and improving those high scores!</>,
         sender: "Academy",
         check: (state)=>(state.formulaGodScores[0] > 1),
         delay: 45
@@ -426,7 +426,7 @@ export const mailDictionary = {
     "TrueHint":{
         id: "TrueHint",
         title: "We have an idea for those Stones.",
-        content: <>Sorry for taking so long, we went down the wrong path for a while: Your starting x now allows you to get the three differentials without using any formulas. But that does not really seem to help you do anything new. Then, upon closer inspection we noticed that with your Starting X it should now be possible to use x''' &#10141; x''' + log<sub>2</sub>(x)<sup>2</sup> as your first formula. Curiously, if one was to apply that formula while x = Infinity, then one could also reach x''' = Infinity.</>,
+        content: <>Sorry for taking so long, we went down the wrong path for a while: Your starting x now allows you to get the three differentials without using any formulas. But that does not really seem to help you do anything new. Then, upon closer inspection we noticed that with your starting x it should now be possible to use x''' &#10141; x''' + log<sub>2</sub>(x)<sup>2</sup> as your first formula. Curiously, if one was to apply that formula while x = Infinity, then one could also reach x''' = Infinity.</>,
         check: (state)=>(true),
         abandon: (state)=>(state.mailsReceived["NoHint"]),
         delay: 30000,
@@ -446,7 +446,7 @@ export const mailDictionary = {
     "Destiny":{
         id: "Destiny",
         title: "Fight the Darkness with me",
-        content: <>Hello, congratulations on finishing the main game! You now have gained access to my realm. My name is Estelle, the goddess of Starlight and sleepless overseer of the eternal night. Sadly, during the last weeks, the night sky has darkened drastically. It became almost devoid of Stars and Starlight. I could really use your help to restore as much of that as possible. Since this is optional post-game content, you can do as little or much of it as you want without really missing out on anything important. But every ray of Starlight counts and helps me! <br/><br/>Here is a quick overview:<br/><br/>Astral Glance: Produces 1 Starlight per Second<br/><br/>Shooting Star: Doubles Starlight Rate<br/><br/>Luminous Moon: Multiplies Starlight Rate with number of Destiny Stars<br/><br/>Gaze at the night sky: Grants 1 Starlight, only possible if there is no other means of generating Starlight<br/><br/>Destiny Reset: Resets the entire main game ("New Game Plus") for a Destiny Star. Only available when the main game is completed.<br/><br/>Destiny Star: The number of Destiny Stars acts as a global multiplier for many aspects of the main game. And, as mentioned before, Destiny Stars boost the effect of Luminous Moons.<br/><br/>Star Constellations: There is a legend that, when the night sky is full of Starlight, all of it can be transformed into a beautiful Star Constellation!</>,
+        content: <>Hello, congratulations on finishing the main game! You now have gained access to my realm. My name is Estelle, the goddess of Starlight and sleepless overseer of the eternal night. Sadly, during the last weeks, the night sky has darkened drastically. It became almost devoid of Stars and Starlight. I could really use your help to restore as much of that as possible. Since this is optional post-game content, you can do as little or much of it as you want without really missing out on anything important. But every ray of Starlight counts and helps me! <br/><br/>Here is a quick overview:<br/><br/>Astral Glance: Produces 1 Starlight per Second<br/><br/>Shooting Star: Doubles Starlight Rate<br/><br/>Luminous Moon: Multiplies Starlight Rate with number of Destiny Stars<br/><br/>Gaze at the night sky: Grants 1 Starlight, only possible if there are no other means of generating Starlight<br/><br/>Destiny Reset: Resets the entire main game ("New Game Plus") for a Destiny Star. Only available when the main game is completed.<br/><br/>Destiny Star: The number of Destiny Stars acts as a global multiplier for many aspects of the main game. And, as mentioned before, Destiny Stars boost the effect of Luminous Moons.<br/><br/>Star Constellations: There is a legend that, when the night sky is full of Starlight, all of it can be transformed into a beautiful Star Constellation!</>,
         sender: "Estelle",
         check: (state)=>(state.destinyStars >= 1),
         delay: 0,
@@ -476,7 +476,7 @@ export const mailDictionary = {
     "Eternal":{
         id: "Eternal",
         title: "The eternal night is over",
-        content: <>This is absolutely incredible. With an Infinity of Starlight, replenishing itself quickly should darkness ever arise again, the eternal night is finally coming to an end, and the Age of Illumination is about to begin. However, the dawn of this new era means that it is time for us to part ways. And that it is time for me to get some rest. But I will hold to the memories of our time together dearly, and take them with me, whereever fate may take me!<br/><br/>Farewell, and thank you for everything!<br/><br/>Estelle</>,
+        content: <>This is absolutely incredible. With an Infinity of Starlight, replenishing itself quickly should darkness ever arise again, the eternal night is finally coming to an end, and the Age of Illumination is about to begin. However, the dawn of this new era means that it is time for us to part ways. And that it is time for me to get some rest. But I will hold to the memories of our time together dearly, and take them with me, wherever fate may take me!<br/><br/>Farewell, and thank you for everything!<br/><br/>Estelle</>,
         sender: "Estelle",
         check: (state)=>(state.starlightRecordMillis <= 120000 && state.starLight >= Infinity && state.lightAdder >= 1000 && state.lightDoubler >= 1000 && state.lightRaiser >= 1000),
         delay: 0,


### PR DESCRIPTION
Like that of the one on my fork, but without changes to the README.md describing that my mod does this.

"highscore(s)" -> "high score(s)" everywhere

"Pop-Up-Settings" and "Hotkey-Settings" in options have the hyphen before "Settings" removed

Mentions of Alpha Runs, World Formula, x value(s), starting x made consistent (e.g. always Alpha Run, not sometimes Alpha-Run or Alpha run)

Alpha Challenge Tab sentence counting challenge and segment completions now adjusts to say "1 completion" instead of "1 completions" if applicable

"PEACE THE PEACES TOGETHER" to "PIECE THE PEACES TOGETHER"

Other minor grammar/spelling fixes